### PR TITLE
Request balances of voter address from the network in bulk

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -300,15 +300,15 @@ export default class App extends Vue {
             );
         }
 
-        // Get balances for address groups
-        for (const group of addressGroups) {
+        // Get balances for address groups in parallel
+        await Promise.all(addressGroups.map(async (group) => {
             const accounts = await client.getAccounts(group);
             accounts.forEach((account, i) => {
                 const address = group[i];
                 // NOTE: The balance includes not-yet-vested NIM in vesting contracts
                 balancesByAddress.set(address, account.balance);
             });
-        }
+        }));
 
         for (const vote of votes) {
             const { sender } = vote.tx;


### PR DESCRIPTION
Network peers rate-limit account requests to a couple per minute. When lots of addresses vote, this will start to fail after 50-100 address requests across all peers. However, accounts can be requested in bulk from the network, where each request still only counts once against the rate-limit.